### PR TITLE
Fix make-breadcrumbs.stub...

### DIFF
--- a/src/Console/Commands/Stubs/make-breadcrumbs.stub
+++ b/src/Console/Commands/Stubs/make-breadcrumbs.stub
@@ -17,7 +17,7 @@ Breadcrumbs::for('admin.DummyRoute.show', function ($trail, $id) {
 
 Breadcrumbs::for('admin.DummyRoute.edit', function ($trail, $id) {
     $trail->parent('admin.DummyRoute.index');
-    $trail->push(__('backend.DummyRoute.labels.edit'), route('admin.DummyRoute.edit', $id));
+    $trail->push(__('backend_DummyRoute.labels.edit'), route('admin.DummyRoute.edit', $id));
 });
 
 Breadcrumbs::for('admin.DummyRoute.deleted', function ($trail) {


### PR DESCRIPTION
 ... to use the right label for the 'edit' breadcrumb.
Replace dot with underscore.