### PR TITLE
Laravel 6 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ It has been tested with Laravel 5.7.
 
 ```
 composer require pqrs/l5b-crud
+composer require laravel/helpers
 ```
 
 ## Run

--- a/README.md
+++ b/README.md
@@ -8,10 +8,10 @@ By default it does not overwrite any files that may exist with the pre-stablishe
 
 ## Requires
 
-- [Laravel 5](https://laravel.com)
+- [Laravel](https://laravel.com)
 - [rappasoft/laravel-5-boilerplate](https://www.github.com/rappasoft/laravel-5-boilerplate/)
 
-It has been tested with Laravel 5.7.
+It has been tested with Laravel 6.0.
 
 ## Install
 

--- a/src/Console/Commands/L5BCrud.php
+++ b/src/Console/Commands/L5BCrud.php
@@ -155,7 +155,7 @@ class L5BCrud extends Command
             'namespace'         => '\Events\Backend\\' . ucfirst(camel_case($key)),
             'event'             => ucfirst(camel_case($key)),
             'model'             => ucfirst(camel_case($key)),
-            'table'             =>  str_plural($key),
+            'table'             => $key,
             'field'             => $this->option('field'),
             '--force'           => $this->hasOption('force') ? $this->option('force') : false,
         ];
@@ -397,7 +397,7 @@ class L5BCrud extends Command
             'namespace'         => '\Events\Frontend\\' . ucfirst(camel_case($key)),
             'event'             => ucfirst(camel_case($key)),
             'model'             => ucfirst(camel_case($key)),
-            'table'             =>  str_plural($key),
+            'table'             => $key,
             'field'             => $this->option('field'),
             '--force'           => $this->hasOption('force') ? $this->option('force') : false,
         ];

--- a/src/Console/Commands/Stubs/make-backend-labels.stub
+++ b/src/Console/Commands/Stubs/make-backend-labels.stub
@@ -37,7 +37,7 @@ return [
     ],
 
     'sidebar' => [
-        'title'  => 'Title',
+        'title'  => 'DummyModel',
     ],
 
     'tabs' => [

--- a/src/Console/Commands/Stubs/make-frontend-repository.stub
+++ b/src/Console/Commands/Stubs/make-frontend-repository.stub
@@ -16,7 +16,7 @@ class DummyRepository extends BaseRepository
     /**
      * DummyRepository constructor.
      *
-     * @param  User  $model
+     * @param  DummyModel  $model
      */
     public function __construct(DummyModel $model)
     {

--- a/src/Console/Commands/Stubs/make-frontend-repository.stub
+++ b/src/Console/Commands/Stubs/make-frontend-repository.stub
@@ -14,6 +14,16 @@ use Illuminate\Pagination\LengthAwarePaginator;
 class DummyRepository extends BaseRepository
 {
     /**
+     * DummyRepository constructor.
+     *
+     * @param  User  $model
+     */
+    public function __construct(DummyModel $model)
+    {
+        $this->model = $model;
+    }
+
+    /**
      * @return string
      */
     public function model()
@@ -60,7 +70,7 @@ class DummyRepository extends BaseRepository
     public function create(array $data) : DummyModel
     {
         return DB::transaction(function () use ($data) {
-            $DummyVariable = parent::create([
+            $DummyVariable = $this->model::create([
                 'DummyField' => $data['DummyField'],
             ]);
 

--- a/src/Console/Commands/Stubs/make-frontend-views-header-buttons.stub
+++ b/src/Console/Commands/Stubs/make-frontend-views-header-buttons.stub
@@ -1,3 +1,3 @@
 <div class="btn-toolbar float-right" role="toolbar" aria-label="@lang('labels.general.toolbar_btn_groups')">
-    <a href="{{ route('admin.DummyRoute.create') }}" class="btn btn-success ml-1" data-toggle="tooltip" title="@lang('backend_DummyRoute.labels.create')"><i class="fas fa-plus-circle"></i></a>
+    <a href="{{ route('frontend.DummyRoute.create') }}" class="btn btn-success ml-1" data-toggle="tooltip" title="@lang('frontend_DummyRoute.labels.create')"><i class="fas fa-plus-circle"></i></a>
 </div><!--btn-toolbar-->

--- a/src/Console/Commands/Stubs/make-frontend-views-header-buttons.stub
+++ b/src/Console/Commands/Stubs/make-frontend-views-header-buttons.stub
@@ -1,3 +1,3 @@
 <div class="btn-toolbar float-right" role="toolbar" aria-label="@lang('labels.general.toolbar_btn_groups')">
-    <a href="{{ route('frontend.DummyRoute.create') }}" class="btn btn-success ml-1" data-toggle="tooltip" title="@lang('labels.frontend.DummyRoute.create_new')"><i class="fas fa-plus-circle"></i></a>
+    <a href="{{ route('admin.DummyRoute.create') }}" class="btn btn-success ml-1" data-toggle="tooltip" title="@lang('backend_DummyRoute.labels.create')"><i class="fas fa-plus-circle"></i></a>
 </div><!--btn-toolbar-->

--- a/src/Console/Commands/Stubs/make-repository.stub
+++ b/src/Console/Commands/Stubs/make-repository.stub
@@ -16,7 +16,7 @@ class DummyRepository extends BaseRepository
     /**
      * DummyRepository constructor.
      *
-     * @param  User  $model
+     * @param  DummyModel  $model
      */
     public function __construct(DummyModel $model)
     {

--- a/src/Console/Commands/Stubs/make-repository.stub
+++ b/src/Console/Commands/Stubs/make-repository.stub
@@ -14,6 +14,16 @@ use Illuminate\Pagination\LengthAwarePaginator;
 class DummyRepository extends BaseRepository
 {
     /**
+     * DummyRepository constructor.
+     *
+     * @param  User  $model
+     */
+    public function __construct(DummyModel $model)
+    {
+        $this->model = $model;
+    }
+
+    /**
      * @return string
      */
     public function model()
@@ -60,7 +70,7 @@ class DummyRepository extends BaseRepository
     public function create(array $data) : DummyModel
     {
         return DB::transaction(function () use ($data) {
-            $DummyVariable = parent::create([
+            $DummyVariable = $this->model::create([
                 'DummyField' => $data['DummyField'],
             ]);
 

--- a/src/Console/Commands/Stubs/make-views-header-buttons.stub
+++ b/src/Console/Commands/Stubs/make-views-header-buttons.stub
@@ -1,3 +1,3 @@
 <div class="btn-toolbar float-right" role="toolbar" aria-label="@lang('labels.general.toolbar_btn_groups')">
-    <a href="{{ route('admin.DummyRoute.create') }}" class="btn btn-success ml-1" data-toggle="tooltip" title="@lang('labels.backend.DummyRoute.create_new')"><i class="fas fa-plus-circle"></i></a>
+    <a href="{{ route('admin.DummyRoute.create') }}" class="btn btn-success ml-1" data-toggle="tooltip" title="@lang('backend_DummyRoute.labels.create')"><i class="fas fa-plus-circle"></i></a>
 </div><!--btn-toolbar-->

--- a/src/Console/Commands/Stubs/make-views-sidebar.stub
+++ b/src/Console/Commands/Stubs/make-views-sidebar.stub
@@ -1,5 +1,5 @@
 <li class="nav-item">
-    <a class="nav-link {{ active_class(Active::checkUriPattern('admin/DummyRoute*')) }}" href="{{ route('admin.DummyRoute.index') }}">
-        <i class="nav-icon icon-folder"></i> @lang('backend_DummyLabel.sidebar.title')
+    <a class="nav-link {{ active_class(Route::is('admin/DummyRoute*')) }}" href="{{ route('admin.DummyRoute.index') }}">
+        <i class="nav-icon fas fa-folder-open"></i> @lang('backend_DummyLabel.sidebar.title')
     </a>
 </li>


### PR DESCRIPTION
This branch enables support for the Laravel 6 version of boilerplate for both the frontend and backend scaffolds.

It also includes some typo fixes on various items (although it does not fix the typo from devanp's PR).